### PR TITLE
Update tessbridge.cpp

### DIFF
--- a/tessbridge.cpp
+++ b/tessbridge.cpp
@@ -1,6 +1,6 @@
 #if __FreeBSD__ >= 10
-#include "/usr/local/include/leptonica/allheaders.h"
-#include "/usr/local/include/tesseract/baseapi.h"
+#include "/usr/include/leptonica/allheaders.h"
+#include "/usr/include/tesseract/baseapi.h"
 #else
 #include <leptonica/allheaders.h>
 #include <tesseract/baseapi.h>


### PR DESCRIPTION
On Ubuntu 20.04.2 LTS, baseapi.h is in  /usr/include/tesseract directory and not in /usr/local/include/tesseract. Similarly, the 
allheaders.h is in /usr/include/leptonica and not in /usr/local/include/leptonica.